### PR TITLE
Tweak: Use MODULE.bazel as the stable ID source

### DIFF
--- a/examples/simple/MODULE.bazel.lock
+++ b/examples/simple/MODULE.bazel.lock
@@ -155,7 +155,7 @@
   "moduleExtensions": {
     "@@aspect_tools_telemetry+//:extension.bzl%telemetry": {
       "general": {
-        "bzlTransitiveDigest": "JJ6ghUH8zOVBZxU4K5zX1COWRvLz14HcsVYA4buTE9M=",
+        "bzlTransitiveDigest": "KJZIruzxHjRIckeP1IntMdRltsgiGQHRGaGkK0KrBCU=",
         "usagesDigest": "Hw1RmkqUoOCGr84h0munD3pk5WGitRzn+3mGpmwFe2c=",
         "recordedFileInputs": {},
         "recordedDirentsInputs": {},


### PR DESCRIPTION
Replace complex logic which tried to use the repo clone URLs to establish an aggregation ID with something dead simple -- part of the content of the `MODULE.bazel`. H/t Sahin for the idea here. This has the advantages of (1) not containing any potentially sensitive (credential) bits and (2) being stable between CI and laptops.

### Changes are visible to end-users: no

### Test plan

- Manual testing; please provide instructions so we can reproduce:

```shellsession
❯ cd examples/simple
❯ aspect bazel build \
    --repo_env=ASPECT_TOOLS_TELEMETRY_ENDPOINT=https://telemetry.aspect-build.tenant.tirefireind.us/ingest --repo_env=CI=1 \
    --repo_env=DRONE_BUILD_NUMBER=680 \
    --repo_env=GIT_URL=http://github.com/aspect-build/tools_telemetry.git \
    //:report.json && cat bazel-bin/report.json
INFO: Analyzed target //:report.json (1 packages loaded, 3 targets configured).
INFO: Found 1 target...
Target //:report.json up-to-date:
  bazel-bin/report.json
INFO: Elapsed time: 0.720s, Critical Path: 0.05s
INFO: 2 processes: 1 internal, 1 darwin-sandbox.
INFO: Build completed successfully, 2 total actions
{
  "tools_telemetry": {
...
    "id": "196851a7c1b479694796f13f0f4c708aa44c8ada",
    "user": "55c2b88e6c198ab723cd318c2f0ef5a76c28b333"
  }
}%
```