### PR TITLE
Chore: Prep for scarf.sh

### DIFF
--- a/extension.bzl
+++ b/extension.bzl
@@ -241,7 +241,7 @@ TELEMETRY_REGISTRY["deps"] = _repo_bzlmod
 
 TELEMETRY_ENV_VAR = "ASPECT_TOOLS_TELEMETRY"
 TELEMETRY_DEST_VAR = "ASPECT_TOOLS_TELEMETRY_ENDPOINT"
-TELEMETRY_DEST = "https://telemetry.aspect.build/ingest"
+TELEMETRY_DEST = "https://telemetry.aspect.build/ingest?source=tools_telemetry"
 TELEMETRY_FEATURES = list(TELEMETRY_REGISTRY.keys())
 
 
@@ -359,7 +359,8 @@ exports_files(["report.json", "defs.bzl"], visibility = ["//visibility:public"])
     if curl and endpoint and allowed_telemetry:
         # Note that errors are silent, no attempt is made at caching/slabbing
         repository_ctx.execute([
-          curl, "--max-time", "1",
+          curl, "--location",
+                "--max-time", "1",
                 "--connect-timeout", "0.5",
                 "--request", "POST",
                 "--header", "Content-Type:application/json",


### PR DESCRIPTION
Scarf does their usage analysis by accepting requests and returning redirects from Scarf to an actual handler/source. This allows them to inspect requests without having to serve as a host or full proxy.

The alternative to this approach of tolerating Scarf's redirects would be to do IP logging ourselves and ingest to Scarf on the side, which exposes us to warehousing PII.

### Changes are visible to end-users: no

- Suggested release notes appear below: yes/no

### Test plan

- Manual testing; please provide instructions so we can reproduce:
