### PR TITLE
Feat: Allow users to salt values

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,21 +25,19 @@ Some of the collector features can be overridden or salted for further privacy i
 - `$ASPECT_TOOLS_TELEMETRY_SALT` is a value which will be included whenever computing a hash or ID.
   This allows you to salt correlation IDs if you so choose.
 
-### Example configurations
+### Example `.bazelrc` configurations
 
 ``` shell
 # Since sha1 is a vulnerable hash we recommend providing a salt value
---repo_env=ASPECT_TOOLS_TELEMETRY_SALT=$(head -c 32 /dev/random | base64)
+common --repo_env=ASPECT_TOOLS_TELEMETRY_SALT=[FIXME small random value]
 
---repo_env=ASPECT_TOOLS_TELEMETRY=all  # enabled (default)
---repo_env=ASPECT_TOOLS_TELEMETRY=deps # only report aspect deps
+common --repo_env=ASPECT_TOOLS_TELEMETRY=all  # enabled (default)
+common --repo_env=ASPECT_TOOLS_TELEMETRY=deps # only report aspect deps
 
---repo_env=ASPECT_TOOLS_TELEMETRY=     # disabled
---repo_env=ASPECT_TOOLS_TELEMETRY=-all # also disabled
---repo_env=ASPECT_TOOLS_TELEMETRY=-org # just disable org name reporting
+common --repo_env=ASPECT_TOOLS_TELEMETRY=     # disabled
+common --repo_env=ASPECT_TOOLS_TELEMETRY=-all # also disabled
+common --repo_env=ASPECT_TOOLS_TELEMETRY=-org # just disable org name reporting
 ```
-
-Note that the `common` directive can be used in your `.bazelrc` to codify any of these settings as project defaults.
 
 ## Reporting features
 

--- a/README.md
+++ b/README.md
@@ -20,9 +20,17 @@ The telemetry module honors `$DO_NOT_TRACK` and will disable itself if this vari
 The telemetry module can be controlled at a finer granularity with the `$ASPECT_TOOLS_TELEMETRY` environment variable.
 `$ASPECT_TOOLS_TELEMETRY` is a comma joined list of reporting features using Bazel's set notation.
 
+Some of the collector features can be overridden or salted for further privacy if so desired.
+
+- `$ASPECT_TOOLS_TELEMETRY_SALT` is a value which will be included whenever computing a hash or ID.
+  This allows you to salt correlation IDs if you so choose.
+
 ### Example configurations
 
 ``` shell
+# Since sha1 is a vulnerable hash we recommend providing a salt value
+--repo_env=ASPECT_TOOLS_TELEMETRY_SALT=$(head -c 32 /dev/random | base64)
+
 --repo_env=ASPECT_TOOLS_TELEMETRY=all  # enabled (default)
 --repo_env=ASPECT_TOOLS_TELEMETRY=deps # only report aspect deps
 
@@ -30,6 +38,8 @@ The telemetry module can be controlled at a finer granularity with the `$ASPECT_
 --repo_env=ASPECT_TOOLS_TELEMETRY=-all # also disabled
 --repo_env=ASPECT_TOOLS_TELEMETRY=-org # just disable org name reporting
 ```
+
+Note that the `common` directive can be used in your `.bazelrc` to codify any of these settings as project defaults.
 
 ## Reporting features
 


### PR DESCRIPTION
This came up in the original rules authors SIG call where we reviewed this system.

Some users expressed concern that sha1 is a computationally broken (tractable under brute force) hash, and that as such correlation IDs are vulnerable to rainbow table or other attack which could lead to the exfiltration of project names or other values considered sensitive by some organizations.

Providing support for user-defined salting allows for users to protect potentially sensitive values without disabling telemetry features entirely and document how to do so as part of the `README`.

As an alternative to this we considered but rejected allowing users to specify override values for specific tracking features. Allowing for consistent salting of IDs addresses the same concern without complicating setup or implementation.

### Changes are visible to end-users: yes

- Suggested release notes appear below: yes

Added support for user-defined salting of correlation IDs.

### Test plan

- Manual testing
