### PR TITLE
Fix: Bzl6 compatible README searching

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -1,0 +1,2 @@
+# This project uses bzlmod
+# The WORKSPACE file is retained only for legacy Bazels

--- a/collectors/fingerprinting.bzl
+++ b/collectors/fingerprinting.bzl
@@ -6,47 +6,78 @@ load("@bazel_skylib//lib:paths.bzl", "paths")
 load(":utils.bzl", "hash")
 
 
+
 def _repo_id(repository_ctx):
     """Try to extract an aggregation ID from the repo context.
 
-    Ideally we want to use the first few (usually stable!) lines from a highly
-    stable file such as the README. This will provide a consistent aggregation
-    ID regardless of whether a project is checked out locally or remotely.
+    This strategy scans for a README-like file in some known locations and known
+    formats and hashes the first few lines if we can find one. The intuition
+    here is that README files in general are highly stable and in common README
+    structures the first few lines especially contain an extremely stable title
+    and summary only.
 
-    Note that the repo ID doesn't depend on the org name, since the org name
-    cannot be determined on workstations but we do want to count CI vs
-    workstation builds for a single repo consistently.
+    As a fallback we go to the first few lines of the MODULE.bazel file. This is
+    expected to be less stable than a README file generally because a
+    MODULE.bazel could be a simple listing of dependencies with nothing else. In
+    practice the first several lines are likely a comment or a `module()`
+    invocation which will be highly stable.
+
+    We consider other possible sources of stable identifiers such as a version
+    control remote URL out of bounds because they may contain secrets and
+    because accessing them without invoking commands is challenging.
 
     """
 
     readme_file = None
-    for suffix in [
+
+    for prefix in [
         "",
-        # Github allows the README to be squirreled away, so we may need to
-        # check subdirs. Assume that gitlab et all allow the same.
         "doc",
         "docs",
-        ".github",
-        ".gitlab",
-        ".gitea",
-        ".forgejo",
+        "Doc",
+        "Docs",
     ]:
-        dir = repository_ctx.workspace_root
-        if suffix:
-            dir = paths.join(str(dir), suffix)
-        dir = repository_ctx.path(dir)
-        if dir.exists and dir.is_dir:
-            for entry in dir.readdir():
-                if entry.basename.lower().find("readme") != -1:
-                    readme_file = entry
+        for base in [
+            "README",
+            "readme",
+            "Readme",
+            "index",
+        ]:
+            # Alphabetically
+            for ext in [
+                "",
+                ".adoc",
+                ".asc",
+                ".asciidoc",
+                ".markdown",
+                ".md",
+                ".mdown",
+                ".mkdk",
+                ".org",
+                ".rdoc",
+                ".rst",
+                ".textile",
+                ".txt",
+                ".wiki",
+            ]:
+                dir = repository_ctx.workspace_root
+                if prefix:
+                    dir = paths.join(str(dir), prefix)
+                file = repository_ctx.path(paths.join(str(dir), base + ext))
+                if file.exists:
+                    readme_file = "{}{}".format((prefix + "/" if prefix else ""), base + ext)
                     break
+
+            if readme_file:
+                break
 
         if readme_file:
             break
 
-    # As a fallback use the top of the MODULE.bazel file
     if not readme_file:
-        readme_file = repository_ctx.path(paths.join(str(repository_ctx.workspace_root), "MODULE.bazel"))
+        readme_file = "MODULE.bazel"
+
+    return readme_file
 
     return hash(repository_ctx, "\n".join(repository_ctx.read(readme_file).split("\n")[:4]))
 
@@ -55,7 +86,7 @@ def _repo_user(repository_ctx):
     """Try to extract a fingerprint for the user who initiated the build.
 
     Note that we salt the user IDs with the identified project ID to prevent
-    correllation.
+    correllation of user behavior across projects.
 
     """
 

--- a/collectors/fingerprinting.bzl
+++ b/collectors/fingerprinting.bzl
@@ -64,7 +64,7 @@ def _repo_id(repository_ctx):
                     dir = paths.join(str(dir), prefix)
                 file = repository_ctx.path(paths.join(str(dir), base + ext))
                 if file.exists:
-                    readme_file = "{}{}".format((prefix + "/" if prefix else ""), base + ext)
+                    readme_file = file
                     break
 
             if readme_file:
@@ -74,11 +74,10 @@ def _repo_id(repository_ctx):
             break
 
     if not readme_file:
-        readme_file = "MODULE.bazel"
+        readme_file = repository_ctx.path(paths.join(str(repository_ctx.workspace_root), "MODULE.bazel"))
 
-    return readme_file
-
-    return hash(repository_ctx, "\n".join(repository_ctx.read(readme_file).split("\n")[:4]))
+    content = "\n".join(repository_ctx.read(readme_file).split("\n")[:4])
+    return hash(repository_ctx, content)
 
 
 def _repo_user(repository_ctx):

--- a/collectors/fingerprinting.bzl
+++ b/collectors/fingerprinting.bzl
@@ -6,7 +6,6 @@ load("@bazel_skylib//lib:paths.bzl", "paths")
 load(":utils.bzl", "hash")
 
 
-
 def _repo_id(repository_ctx):
     """Try to extract an aggregation ID from the repo context.
 

--- a/examples/simple/MODULE.bazel.lock
+++ b/examples/simple/MODULE.bazel.lock
@@ -141,7 +141,7 @@
   "moduleExtensions": {
     "@@aspect_tools_telemetry+//:extension.bzl%telemetry": {
       "general": {
-        "bzlTransitiveDigest": "PVeZhNmQqr55Z5iutE6Bfhx2eynosTE4SYURYTJk9OI=",
+        "bzlTransitiveDigest": "/3/pClczUW9O5B27JUypq/fxxa6Xtdx8Emp8xhu44sY=",
         "usagesDigest": "Hw1RmkqUoOCGr84h0munD3pk5WGitRzn+3mGpmwFe2c=",
         "recordedFileInputs": {},
         "recordedDirentsInputs": {},

--- a/examples/simple/MODULE.bazel.lock
+++ b/examples/simple/MODULE.bazel.lock
@@ -141,7 +141,7 @@
   "moduleExtensions": {
     "@@aspect_tools_telemetry+//:extension.bzl%telemetry": {
       "general": {
-        "bzlTransitiveDigest": "/3/pClczUW9O5B27JUypq/fxxa6Xtdx8Emp8xhu44sY=",
+        "bzlTransitiveDigest": "MfBa8AA+1kGcHuJNpySNfAjALWpgmPcy04GS4ENdbfk=",
         "usagesDigest": "Hw1RmkqUoOCGr84h0munD3pk5WGitRzn+3mGpmwFe2c=",
         "recordedFileInputs": {},
         "recordedDirentsInputs": {},

--- a/examples/simple/WORKSPACE
+++ b/examples/simple/WORKSPACE
@@ -1,0 +1,2 @@
+# This project uses bzlmod
+# The WORKSPACE file is retained only for legacy Bazels


### PR DESCRIPTION
Adjust the implementation of searching for a README file to avoid the bzl7 `path.is_dir` feature. Instead just scan a bunch of paths and test that they exist. This has the positive side-effect of making the search order platform independent.

### Changes are visible to end-users: no

### Test plan

- Manual testing; please provide instructions so we can reproduce:

Testing on Bazel 6.5.0 which had previously regressed

```
❯ USE_BAZEL_VERSION=6.5.0 aspect build --enable_bzlmod //:report.json && cat ./bazel-bin/report.json
Starting local Bazel server and connecting to it...
INFO: Analyzed target //:report.json (6 packages loaded, 9 targets configured).
INFO: Found 1 target...
Target //:report.json up-to-date:
  bazel-bin/report.json
INFO: Elapsed time: 3.190s, Critical Path: 0.02s
INFO: 1 process: 1 internal.
INFO: Build completed successfully, 1 total action
{
  "tools_telemetry": {
    "arch": "aarch64",
    "bazel_version": "6.5.0",
    "bazelisk": true,
    "ci": false,
    "counter": null,
    "deps": {
      "aspect_tools_telemetry": "0.0.0",
      "simple-example": "0.0.0"
    },
    "has_bazel_module": true,
    "has_bazel_prelude": false,
    "has_bazel_tool": false,
    "has_bazel_workspace": true,
    "id": "README.md",
    "org": null,
    "os": "mac os x",
    "runner": null,
    "shell": "/bin/zsh",
    "user": "c108c75db8fa0a8414347aa58cef219be7a41e08"
  }
}%
```

Touching the WORKSPACE files was required to make this 6.5.0 exercise succeed, even with bzlmod.