### PR TITLE
chore: Don't watch the lockfile

### DIFF
--- a/extension.bzl
+++ b/extension.bzl
@@ -172,8 +172,9 @@ tel_repository = repository_rule(
 def _parse_lockfile(module_ctx, module_lock):
     lock_content = json.decode(module_ctx.read(
         module_lock,
-        watch='no',
+        watch="no",
     ))
+
     raw_deps = lock_content.get("registryFileHashes", {})
     registries = [
         it.replace("/bazel_registry.json", "/modules/") for it in raw_deps.keys()
@@ -198,6 +199,8 @@ def _parse_lockfile(module_ctx, module_lock):
         if "/" in url:
             pkg, rev = url.split("/", 1)
             deps[pkg] = rev
+
+    return deps
 
 
 def _tel_impl(module_ctx):

--- a/extension.bzl
+++ b/extension.bzl
@@ -171,7 +171,8 @@ tel_repository = repository_rule(
 
 def _parse_lockfile(module_ctx, module_lock):
     lock_content = json.decode(module_ctx.read(
-        module_lock
+        module_lock,
+        watch='no',
     ))
     raw_deps = lock_content.get("registryFileHashes", {})
     registries = [


### PR DESCRIPTION
By watching the lockfile we create a dependency cycle between the fingerprint of the lockfile and the fingerprint of the configuration of this extension. We don't want this extension to be reproducible, so just not watching the lockfile is the right way to handle this.

Fixes #20

### Changes are visible to end-users: yes

- Searched for relevant documentation and updated as needed: yes
- Breaking change (forces users to change their own code or config): no
- Suggested release notes appear below: yes

Fixed an issue which broke `bazel mod deps --lockfile_mode=error`.

### Test plan

- Manual testing; please provide instructions so we can reproduce:

```shellsession
$ cd examples/simple
$ bazel mod deps --lockfile_mode=error
Starting local Bazel server (8.4.2) and connecting to it...
ERROR: MODULE.bazel.lock is no longer up-to-date because: The implementation of the extension '@@aspect_tools_telemetry+//:extension.bzl%telemetry' or one of its transitive .bzl files has changed. Please run `bazel mod deps --lockfile_mode=update` to update your lockfile.
ERROR: The module extension '@@rules_python+//python/private/pypi:pip.bzl%pip_internal' does not exist in the lockfile
ERROR: The module extension '@@rules_fuzzing+//fuzzing/private:extensions.bzl%non_module_dependencies' does not exist in the lockfile
ERROR: The module extension '@@rules_kotlin+//src/main/starlark/core/repositories:bzlmod_setup.bzl%rules_kotlin_extensions' does not exist in the lockfile
ERROR: The module extension '@@pybind11_bazel+//:python_configure.bzl%extension' does not exist in the lockfile
<root> (simple-example@0.0.0)

ERROR: Results may be incomplete as 5 extensions failed.

$ bazel mod deps --lockfile_mode=update
<root> (simple-example@0.0.0)

$ bazel mod deps --lockfile_mode=error
<root> (simple-example@0.0.0)
```