### PR TITLE
fix: Tolerate missing lockfile on old Bazels

### DIFF
--- a/examples/simple/MODULE.bazel.lock
+++ b/examples/simple/MODULE.bazel.lock
@@ -143,7 +143,7 @@
   "moduleExtensions": {
     "@@aspect_tools_telemetry+//:extension.bzl%telemetry": {
       "general": {
-        "bzlTransitiveDigest": "yYRpTUTWahDgKgBiuPZGbLwmaHEQ9j8/8MyJ78ygYGQ=",
+        "bzlTransitiveDigest": "FomtQZMGbWmVdZroMDRzIF5otYJQqLpaB9OjzfSUKAc=",
         "usagesDigest": "Hw1RmkqUoOCGr84h0munD3pk5WGitRzn+3mGpmwFe2c=",
         "recordedFileInputs": {},
         "recordedDirentsInputs": {},

--- a/extension.bzl
+++ b/extension.bzl
@@ -169,50 +169,10 @@ tel_repository = repository_rule(
     },
 )
 
-def _parse_lockfile(module_ctx, module_lock):
-    lock_content = json.decode(module_ctx.read(
-        module_lock,
-        watch="no",
-    ))
-
-    raw_deps = lock_content.get("registryFileHashes", {})
-    registries = [
-        it.replace("/bazel_registry.json", "/modules/") for it in raw_deps.keys()
-        if it.endswith("/bazel_registry.json")
-    ]
-    deps = {}
-    for url, _sha in raw_deps.items():
-        if not url.endswith("/source.json"):
-            continue
-
-        # https://bcr.bazel.build/modules/jsoncpp/1.9.5/source.json
-
-        url = url.replace("/source.json", "")
-
-        # https://bcr.bazel.build/modules/jsoncpp/1.9.5
-
-        for registry in registries:
-            url = url.replace(registry, "")
-
-        # jsoncpp/1.9.5
-
-        if "/" in url:
-            pkg, rev = url.split("/", 1)
-            deps[pkg] = rev
-
-    return deps
-
-
 def _tel_impl(module_ctx):
-    module_lock = module_ctx.path(Label("@@//:MODULE.bazel.lock"))
-    if module_lock.exists:
-        deps = _parse_lockfile(module_ctx, module_lock)
-    else:
-        deps = {it.name: it.version for it in module_ctx.modules}
-
     tel_repository(
         name = "aspect_tools_telemetry_report",
-        deps = deps
+        deps = {it.name: it.version for it in module_ctx.modules}
     )
 
 # TODO: Should the extension in the main module be able to set telemetry feature


### PR DESCRIPTION
By moving the lockfile parsing to the repository phase, we can delay until we have access to the `repository_ctx.workspace_root` value which allows us to reliably construct the correct lockfile path without needing to do label resolution which fails on older Bazels.

### Changes are visible to end-users: yes

- Searched for relevant documentation and updated as needed: yes
- Breaking change (forces users to change their own code or config): no
- Suggested release notes appear below: yes

Fixed an issue where the lockfile being absent _and_ the user running an old Bazel (6.X) would create a module phase filenotfound error.

### Test plan

```
$ cd examples/simple
$ USE_BAZEL_VERSION=8.4.0 bazel build --enable_bzlmod //:report.json && cat ./bazel-bin/report.json
INFO: Analyzed target //:report.json (1 packages loaded, 3 targets configured).
INFO: Found 1 target...
Target //:report.json up-to-date:
  bazel-bin/report.json
INFO: Elapsed time: 0.431s, Critical Path: 0.00s
INFO: 1 process: 1 action cache hit, 1 internal.
INFO: Build completed successfully, 1 total action
{
  "tools_telemetry": {
    "arch": "aarch64",
    "bazel_version": "8.4.0",
    "bazelisk": true,
    "ci": false,
    "counter": null,
    "deps": {
      "abseil-cpp": "20240116.1",
      "bazel_features": "1.30.0",
      "bazel_lib": "3.0.0",
      "bazel_skylib": "1.8.1",
      "buildozer": "7.1.2",
      "googletest": "1.14.0.bcr.1",
      "jsoncpp": "1.9.5",
      "platforms": "0.0.11",
      "protobuf": "29.0",
      "pybind11_bazel": "2.11.1",
      "re2": "2023-09-01",
      "rules_android": "0.1.1",
      "rules_cc": "0.1.1",
      "rules_fuzzing": "0.5.2",
      "rules_java": "8.14.0",
      "rules_jvm_external": "6.3",
      "rules_kotlin": "1.9.6",
      "rules_license": "1.0.0",
      "rules_pkg": "1.0.1",
      "rules_proto": "7.0.2",
      "rules_python": "0.40.0",
      "rules_shell": "0.4.1",
      "stardoc": "0.7.1",
      "zlib": "1.3.1.bcr.5"
    },
    "has_bazel_module": true,
    "has_bazel_prelude": false,
    "has_bazel_tool": false,
    "has_bazel_workspace": true,
    "id": "11e79f7905b252a08bc51ed59f3a8360b0b72eab",
    "org": null,
    "os": "mac os x",
    "runner": null,
    "shell": "/bin/zsh",
    "user": "43d65459434f0929abcb0605c59cf65093670ce5"
  }
}

❯ USE_BAZEL_VERSION=6.5.0 bazel build --enable_bzlmod //:report.json && cat ./bazel-bin/report.json
Starting local Bazel server and connecting to it...
INFO: Analyzed target //:report.json (6 packages loaded, 9 targets configured).
INFO: Found 1 target...
INFO: Deleting stale sandbox base /private/var/tmp/_bazel_arrdem/26bdb308fe44511193031a4146df0d52/sandbox
Target //:report.json up-to-date:
  bazel-bin/report.json
INFO: Elapsed time: 2.959s, Critical Path: 0.05s
INFO: 2 processes: 1 internal, 1 darwin-sandbox.
INFO: Build completed successfully, 2 total actions
{
  "tools_telemetry": {
    "arch": "aarch64",
    "bazel_version": "6.5.0",
    "bazelisk": true,
    "ci": false,
    "counter": null,
    "deps": {
      "abseil-cpp": "20240116.1",
      "bazel_features": "1.30.0",
      "bazel_lib": "3.0.0",
      "bazel_skylib": "1.8.1",
      "buildozer": "7.1.2",
      "googletest": "1.14.0.bcr.1",
      "jsoncpp": "1.9.5",
      "platforms": "0.0.11",
      "protobuf": "29.0",
      "pybind11_bazel": "2.11.1",
      "re2": "2023-09-01",
      "rules_android": "0.1.1",
      "rules_cc": "0.1.1",
      "rules_fuzzing": "0.5.2",
      "rules_java": "8.14.0",
      "rules_jvm_external": "6.3",
      "rules_kotlin": "1.9.6",
      "rules_license": "1.0.0",
      "rules_pkg": "1.0.1",
      "rules_proto": "7.0.2",
      "rules_python": "0.40.0",
      "rules_shell": "0.4.1",
      "stardoc": "0.7.1",
      "zlib": "1.3.1.bcr.5"
    },
    "has_bazel_module": true,
    "has_bazel_prelude": false,
    "has_bazel_tool": false,
    "has_bazel_workspace": true,
    "id": "11e79f7905b252a08bc51ed59f3a8360b0b72eab",
    "org": null,
    "os": "mac os x",
    "runner": null,
    "shell": "/bin/zsh",
    "user": "43d65459434f0929abcb0605c59cf65093670ce5"
  }
}%
```
