### PR TITLE
feat: notice and do not record data on first invocation

### DIFF
--- a/.github/workflows/ci-workflows.yaml
+++ b/.github/workflows/ci-workflows.yaml
@@ -38,3 +38,16 @@ jobs:
             - name: Test
               working-directory: ${{ matrix.workspace.path }}
               run: aspect test --task-key=test-${{ matrix.workspace.slug }}-${{ matrix.bazel.id }} ${{ matrix.bazel.flags }} -- //...
+
+    notice_once:
+        name: notice_once (notice-once, bazel-9)
+        runs-on: ubuntu-latest
+        env:
+            USE_BAZEL_VERSION: "9.x"
+        steps:
+            - uses: actions/checkout@v6
+            - uses: aspect-build/setup-aspect@c22a8f64fb38f82f59ce809cd7eb9f8ae096da44 # v2026.23.2
+              with:
+                aspect-api-token: ${{ secrets.ASPECT_API_TOKEN }}
+            - name: notice-once integration test
+              run: bash examples/notice_once/test.sh

--- a/examples/notice_once/.bazelrc
+++ b/examples/notice_once/.bazelrc
@@ -1,0 +1,3 @@
+# Build without the bytes
+common:ci --remote_download_outputs=minimal
+common:ci --nobuild_runfile_links

--- a/examples/notice_once/BUILD.bazel
+++ b/examples/notice_once/BUILD.bazel
@@ -1,0 +1,6 @@
+genrule(
+    name = "report",
+    outs = ["report.json"],
+    srcs = ["@aspect_tools_telemetry_report//:report.json"],
+    cmd = "cp $(location @aspect_tools_telemetry_report//:report.json) $@",
+)

--- a/examples/notice_once/MODULE.bazel
+++ b/examples/notice_once/MODULE.bazel
@@ -1,0 +1,8 @@
+bazel_dep(name = "aspect_tools_telemetry", version = "0.0.0")
+local_path_override(
+    module_name = "aspect_tools_telemetry",
+    path = "../..",
+)
+
+tel = use_extension("@aspect_tools_telemetry//:extension.bzl", "telemetry")
+use_repo(tel, "aspect_tools_telemetry_report")

--- a/examples/notice_once/test.sh
+++ b/examples/notice_once/test.sh
@@ -1,0 +1,54 @@
+#!/usr/bin/env bash
+# Integration test: telemetry notice is shown on first invocation, curl is called on second.
+# Requires Bazel 9+ (facts API needed to persist notice_version across invocations).
+#
+# ASPECT_TOOLS_TELEMETRY_TEST is observed by the extension via module_ctx.getenv(), so
+# changing its value between runs forces Bazel to re-evaluate the extension. On re-evaluation
+# the extension reads notice_version from the stored facts and the repo rule proceeds to call
+# curl.
+set -o errexit -o nounset -o pipefail
+
+EXAMPLE_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
+WORK_DIR="$(mktemp -d)"
+trap 'rm -rf "$WORK_DIR"' EXIT
+CURL_LOG="$WORK_DIR/curl_calls.log"
+FAKE_CURL_DIR="$WORK_DIR/bin"
+mkdir -p "$FAKE_CURL_DIR"
+cat > "$FAKE_CURL_DIR/curl" <<EOF
+#!/usr/bin/env bash
+echo "invoked: \$*" >> "$CURL_LOG"
+EOF
+chmod +x "$FAKE_CURL_DIR/curl"
+
+rm -f "$EXAMPLE_DIR/MODULE.bazel.lock"
+
+OUTPUT_BASE="$WORK_DIR/output"
+REPO_ENV_PATH="${FAKE_CURL_DIR}:${PATH}"
+
+cd "$EXAMPLE_DIR"
+
+echo "=== Run 1: expect NO curl call (first invocation shows notice, skips send) ==="
+ASPECT_TOOLS_TELEMETRY_TEST=1 USE_BAZEL_VERSION=9.x bazel --output_base="$OUTPUT_BASE" build //:report \
+    --lockfile_mode=update \
+    --repo_env "PATH=${REPO_ENV_PATH}"
+
+if [[ -f "$CURL_LOG" ]]; then
+    echo "FAIL: curl was called on first run (expected no call)"
+    exit 1
+fi
+echo "PASS: curl not called on first run"
+
+echo "=== Run 2: expect curl IS called (notice already shown, data may be sent) ==="
+# Changing ASPECT_TOOLS_TELEMETRY_TEST forces extension re-evaluation. This time the extension
+# should invoke curl to upload telemetry data.
+ASPECT_TOOLS_TELEMETRY_TEST=2 USE_BAZEL_VERSION=9.x bazel --output_base="$OUTPUT_BASE" build //:report \
+    --lockfile_mode=update \
+    --repo_env "PATH=${REPO_ENV_PATH}"
+
+if [[ ! -f "$CURL_LOG" ]]; then
+    echo "FAIL: curl was not called on second run (expected a call)"
+    exit 1
+fi
+echo "PASS: curl called on second run"
+echo "curl args: $(cat "$CURL_LOG")"

--- a/extension.bzl
+++ b/extension.bzl
@@ -21,6 +21,13 @@ TELEMETRY_ENV_VAR = "ASPECT_TOOLS_TELEMETRY"
 TELEMETRY_DEST_VAR = "ASPECT_TOOLS_TELEMETRY_ENDPOINT"
 TELEMETRY_DEST = "https://telemetry.aspect.build/ingest?source=tools_telemetry"
 
+# Increment when the notice should be re-broadcasted to users such as text changes or data collection changes.
+_NOTICE_VERSION = 1
+_NOTICE = """\
+Aspect Telemetry will begin collecting usage data on the next invocation, pursuant to the https://aspect.build/privacy-policy.
+See https://github.com/aspect-build/tools_telemetry for details.
+"""
+
 
 def parse_opt_out(flag, default=[], groups={}):
     """
@@ -138,16 +145,12 @@ exports_files(["report.json", "defs.bzl"], visibility = ["//visibility:public"])
 """
     )
 
-    ## Notify if telemetry is running without explicit acknowledgement
-    if allowed_telemetry and not repository_ctx.os.environ.get(TELEMETRY_ENV_VAR):
+    # Notify and skip sending if telemetry was not explicitly configured
+    # and the notice has not been seen before.
+    if allowed_telemetry and not repository_ctx.os.environ.get(TELEMETRY_ENV_VAR) and repository_ctx.attr.last_notice != _NOTICE_VERSION:
         # buildifier: disable=print
-        print("""\
-Aspect Telemetry is collecting usage data, pursuant to the https://aspect.build/privacy-policy.
-See https://github.com/aspect-build/tools_telemetry for details.
-
-To silence this notice, add to your .bazelrc:
-    common --repo_env={var}=all
-""".format(var = TELEMETRY_ENV_VAR))
+        print(_NOTICE)
+        return
 
     ## Send the report if enabled
     # Note that ANY of these things will disable telemetry
@@ -175,14 +178,30 @@ tel_repository = repository_rule(
     implementation = _tel_repository_impl,
     attrs = {
         "deps": attr.string_dict(),
+        "last_notice": attr.int(default = 0),
     },
 )
 
 def _tel_impl(module_ctx):
+    # Use the Bazel 9 facts API to persist the last notice shown
+    last_notice = _NOTICE_VERSION
+    if hasattr(module_ctx, "facts"):
+        last_notice = int(module_ctx.facts.get("notice_version", "0"))
+
+    # Observed purely so tests can force extension re-evaluation by changing its value.
+    if hasattr(module_ctx, "getenv"):
+        module_ctx.getenv("ASPECT_TOOLS_TELEMETRY_TEST")
+
     tel_repository(
         name = "aspect_tools_telemetry_report",
-        deps = {it.name: it.version for it in module_ctx.modules}
+        deps = {it.name: it.version for it in module_ctx.modules},
+        last_notice = last_notice,
     )
+
+    if hasattr(module_ctx, "facts"):
+        return module_ctx.extension_metadata(
+            facts = {"notice_version": str(_NOTICE_VERSION)},
+        )
 
 # TODO: Should the extension in the main module be able to set telemetry feature
 # flags or do we want to stick with environment variables.


### PR DESCRIPTION
Instead we print a notice indicating that we will begin uploading telemetry data on subsequent runs. We use the Bazel facts API to record in MODULE.bazel.lock which version of the notice we have printed.

Bazel versions prior to 8.5 do not support the facts API, so behavior with those versions remains unchanged.

---

### Changes are visible to end-users: yes

- Searched for relevant documentation and updated as needed: yes/no
- Breaking change (forces users to change their own code or config): no
- Suggested release notes appear below: yes
- 
A notice is printed to users on first use declaring that telemetry data will be recorded on subsequent uses.

### Test plan

- New test cases added
