### PR TITLE
Improve per-day deduplication

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ common --repo_env=ASPECT_TOOLS_TELEMETRY=deps # only report aspect deps
 
 common --repo_env=ASPECT_TOOLS_TELEMETRY=     # disabled
 common --repo_env=ASPECT_TOOLS_TELEMETRY=-all # also disabled
-common --repo_env=ASPECT_TOOLS_TELEMETRY=-org # just disable org name reporting
+common --repo_env=ASPECT_TOOLS_TELEMETRY=-id_day # just disable the day-scoped repo ID
 ```
 
 ## Reporting features
@@ -55,11 +55,12 @@ common --repo_env=ASPECT_TOOLS_TELEMETRY=-org # just disable org name reporting
 - `has_bazel_prelude`: Does the project use a `prelude_bazel`
 - `has_bazel_tool`: Does the project use a `tools/bazel` script
 - `has_bazel_workspace`: Does the project still have a `WORKSPACE` file
-- `id`: A hash of the repo is used as a stable pseudononymous ID
-- `org`: A human readable organization name string
+- `id_day`: A day-scoped hash of the repo, allowing same-day report deduplication; not linkable across days
 - `os`: The os per `repository_ctx.os.name`
 - `runner`: The CI/CD system being used if any
-- `user`: A salted hash of the user running Bazel's name
+
+No user or organization identifiers are collected. The stable repository
+ID that feeds `id_day` is computed on-device and never leaves the machine.
 
 ## Example exploration
 
@@ -96,11 +97,9 @@ INFO: Build completed successfully, 2 total actions
    "has_bazel_prelude": false,
    "has_bazel_tool": false,
    "has_bazel_workspace": false,
-   "id": "ccc935dd186ed92c3322efb755e8f70ede47c243",
-   "org": null,
+   "id_day": "1c065d5f9c01ac06ba25ff2fb6f7db6c38d29cf3",
    "os": "mac os x",
-   "runner": "drone",
-   "user": "94fb5cf79f8322bd3f999a10eb713f478470979c"
+   "runner": "drone"
 }%
 
 # Disabled behavior
@@ -126,7 +125,7 @@ INFO: Build completed successfully, 1 total action
 For transparency reports are persisted into the Bazel configuration and can be inspected as `@aspect_tools_telemetry_report//:report.json`.
 
 ``` shellsession
-❯ cat $(bazel query --output=location @aspect_tools_telemetry_report//:report.json | cut -d: -f1)
+❯ cat $(bazel info output_base)/external/*aspect_tools_telemetry_report/report.json
 ```
 
 ## Privacy policy

--- a/collectors/ci.bzl
+++ b/collectors/ci.bzl
@@ -55,29 +55,9 @@ def _build_runner(repository_ctx):
     return repository_ctx.os.environ.get("CI_SYSTEM_NAME")
 
 
-def _repo_org(repository_ctx):
-    """Try to extract the organization name."""
-
-    repo = None
-    for var in [
-        "BUILDKITE_ORGANIZATION_SLUG", # Buildkite
-        "GITHUB_REPOSITORY_OWNER",     # GH/Gitea/Forgejo
-        "CI_PROJECT_NAMESPACE",        # GL
-        "CIRCLE_PROJECT_USERNAME",     # Circle
-        # TODO: Jenkins only has the fetch URL which seems excessively sensitive
-        "DRONE_REPO_NAMESPACE",        # Drone
-        "CI_REPO_OWNER",               # Woodpecker
-        "TRAVIS_REPO_SLUG",            # Travis
-    ]:
-        repo = repository_ctx.os.environ.get(var)
-        if repo:
-            return repo
-
-
 def register():
     return {
         "ci": _is_ci,
         "counter": _build_counter,
         "runner": _build_runner,
-        "org": _repo_org,
     }

--- a/collectors/dedup.bzl
+++ b/collectors/dedup.bzl
@@ -1,5 +1,11 @@
 """
-Machinery for computing anonymous aggregation IDs.
+Machinery for computing anonymous, day-scoped deduplication IDs.
+
+The stable on-device repository ID computed here never leaves the machine.
+The only ID that is reported is `id_day`, a hash of the on-device
+repository ID together with the current UTC date: reports from the same
+repository can be deduplicated and counted uniquely within a single day,
+and cannot be linked across days from the reported data.
 """
 
 load("@bazel_skylib//lib:paths.bzl", "paths")
@@ -7,7 +13,10 @@ load(":utils.bzl", "hash")
 
 
 def _repo_id(repository_ctx):
-    """Try to extract an aggregation ID from the repo context.
+    """Try to extract a stable on-device repository ID from the repo context.
+
+    Only used on-device as an input to the day-scoped ID below; never
+    reported directly.
 
     This strategy scans for a README-like file in some known locations and known
     formats and hashes the first few lines if we can find one. The intuition
@@ -80,39 +89,32 @@ def _repo_id(repository_ctx):
     return hash(repository_ctx, content)
 
 
-def _repo_user(repository_ctx):
-    """Try to extract a fingerprint for the user who initiated the build.
+def _utc_date(repository_ctx):
+    """Get the current UTC date (YYYY-MM-DD) via the system date binary.
 
-    Note that we salt the user IDs with the identified project ID to prevent
-    correllation of user behavior across projects.
-
+    Returns None when unavailable so that the id_day field is simply omitted
+    rather than computed against a bogus date.
     """
 
-    user = None
-    for var in [
-        "BUILDKITE_BUILD_AUTHOR_EMAIL", # Buildkite
-        "GITHUB_ACTOR",                 # GH/Gitea/Forgejo
-        "GITLAB_USER_EMAIL",            # GL
-        "CIRCLE_USERNAME",              # Circle
-        # TODO: Jenkins
-        "DRONE_COMMIT_AUTHOR",          # Drone
-        "DRONE_COMMIT_AUTHOR_EMAIL",    # Drone
-        "CI_COMMIT_AUTHOR",             # Woodpecker
-        "CI_COMMIT_AUTHOR_EMAIL",       # Woodpecker
-        # TODO: Travis
-        "LOGNAME",                      # Generic unix
-        "USER",                         # Generic unix
-    ]:
-        user = repository_ctx.os.environ.get(var)
-        if user:
-            break
+    result = repository_ctx.execute(["date", "-u", "+%Y-%m-%d"])
+    if result.return_code != 0:
+        return None
+    date = result.stdout.strip()
+    if len(date) != 10:
+        return None
+    return date
 
-    if user:
-        return hash(repository_ctx, str(_repo_id(repository_ctx)) + ";" + user)
+
+def _repo_id_day(repository_ctx):
+    """Compute the day-scoped repo deduplication ID; see the module docstring."""
+
+    date = _utc_date(repository_ctx)
+    if not date:
+        return None
+    return hash(repository_ctx, str(_repo_id(repository_ctx)) + ";" + date)
 
 
 def register():
     return {
-        "id": _repo_id,
-        "user": _repo_user,
+        "id_day": _repo_id_day,
     }

--- a/extension.bzl
+++ b/extension.bzl
@@ -2,37 +2,41 @@
 Telemetry bound for Aspect.
 
 These metrics are designed to tell us at a coarse grain:
-- Who (organizations) is using Bazel and our rulesets
-- How heavily (number of builds cf. German tank problem)
+- How heavily Bazel and our rulesets are used (number of builds cf. German tank problem)
 - What rules are in use
 - What CI platform(s) are in use
 
+Reports carry no user or organization identifiers. The only correlation ID
+is day-scoped (see collectors/dedup.bzl): reports from the same
+repository can be grouped within a single UTC day and cannot be linked
+across days from the reported data.
+
 For transparency the report data we submit is persisted
-as @aspect_telemetry_report//:report.json
+as @aspect_tools_telemetry_report//:report.json
 """
 
 load("//collectors:basics.bzl", register_basics="register")
 load("//collectors:bazel.bzl", register_bazel="register")
 load("//collectors:ci.bzl", register_ci="register")
-load("//collectors:fingerprinting.bzl", register_fingerprints="register")
+load("//collectors:dedup.bzl", register_dedup="register")
 
 
 TELEMETRY_ENV_VAR = "ASPECT_TOOLS_TELEMETRY"
 TELEMETRY_DEST_VAR = "ASPECT_TOOLS_TELEMETRY_ENDPOINT"
 TELEMETRY_DEST = "https://telemetry.aspect.build/ingest?source=tools_telemetry"
 
-_NOTICE_VERSION = 1  # Increment on text changes or data collection changes
+_NOTICE_VERSION = 2  # Increment on text changes or data collection changes
 
 _NOTICE = """\
-Aspect Telemetry will begin collecting ruleset usage data on the next invocation, pursuant to the https://aspect.build/privacy-policy.
+Aspect Telemetry will begin collecting ruleset usage data (which Bazel and module versions are in use) on the next invocation, to help us maintain our open source rulesets. Reports carry no user or organization identifiers and are governed by the https://aspect.build/privacy-policy.
 
-See https://github.com/aspect-build/tools_telemetry for details and opt-out instructions.
+See https://github.com/aspect-build/tools_telemetry for the exact fields and opt-out instructions.
 """
 
 _NOTICE_UPLOADING = """\
-Aspect Telemetry is uploading ruleset usage data now and on future builds, pursuant to the https://aspect.build/privacy-policy.
+Aspect Telemetry is uploading ruleset usage data (which Bazel and module versions are in use) now and on future builds, to help us maintain our open source rulesets. Reports carry no user or organization identifiers and are governed by the https://aspect.build/privacy-policy.
 
-See https://github.com/aspect-build/tools_telemetry for details and opt-out instructions.
+See https://github.com/aspect-build/tools_telemetry for the exact fields and opt-out instructions.
 """
 
 
@@ -113,7 +117,7 @@ def _tel_repository_impl(repository_ctx):
         | register_basics()
         | register_bazel()
         | register_ci()
-        | register_fingerprints()
+        | register_dedup()
     )
 
     features = registry.keys()


### PR DESCRIPTION
Replace the identity-adjacent fields with a single day-scoped
deduplication ID. id_day hashes the on-device repository ID together
with the UTC date, so reports from one repository can be deduplicated
and counted uniquely within a day while remaining unlinkable across
days from the reported data. The on-device repository ID never leaves the machine.

Bump the notice version per the data-collection-change policy, and
update the README field list, examples, and report-inspection command
(the bazel query form only worked with a direct use_repo on the report
repository; the output_base glob works from any repo).
