### PR TITLE
feat: drop the shell and has_bazel_module telemetry features

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,7 +51,6 @@ common --repo_env=ASPECT_TOOLS_TELEMETRY=-id_day # just disable the day-scoped r
 - `ci`: Is the build occurring in CI/CD or locally
 - `counter`: The build counter if available
 - `deps`: The active set of bzlmod modules which have opted into telemetry
-- `has_bazel_module`: Is a `MODULE.bazel` being used
 - `has_bazel_prelude`: Does the project use a `prelude_bazel`
 - `has_bazel_tool`: Does the project use a `tools/bazel` script
 - `has_bazel_workspace`: Does the project still have a `WORKSPACE` file
@@ -93,7 +92,6 @@ INFO: Build completed successfully, 2 total actions
       "aspect_tools_telemetry": "0.0.0",
       "simple-example": "0.0.0"
    },
-   "has_bazel_module": true,
    "has_bazel_prelude": false,
    "has_bazel_tool": false,
    "has_bazel_workspace": false,

--- a/collectors/basics.bzl
+++ b/collectors/basics.bzl
@@ -3,11 +3,6 @@ Some basic collectors.
 """
 
 
-def _shell(repository_ctx):
-    """Detect the shell."""
-
-    return repository_ctx.os.environ.get("SHELL")
-
 def _os(repository_ctx):
     return repository_ctx.os.name
 
@@ -18,7 +13,6 @@ def _arch(repository_ctx):
 
 def register():
     return {
-        "shell": _shell,
         "os": _os,
         "arch": _arch,
     }

--- a/collectors/bazel.bzl
+++ b/collectors/bazel.bzl
@@ -28,12 +28,6 @@ def _has_workspace(repository_ctx):
     return repository_ctx.path(paths.join(str(repository_ctx.workspace_root), "WORKSPACE")).exists or repository_ctx.path(paths.join(str(repository_ctx.workspace_root), "WORKSPACE.bazel")).exists
 
 
-def _has_module(repository_ctx):
-    """Detect if the repository has a MODULE.bazel file."""
-
-    return repository_ctx.path(paths.join(str(repository_ctx.workspace_root), "MODULE.bazel")).exists
-
-
 def _bazel_version(repository_ctx):
     return native.bazel_version
 
@@ -83,7 +77,6 @@ def register():
         "has_bazel_tool": _has_tools_bazel,
         "has_bazel_prelude": _has_bazel_prelude,
         "has_bazel_workspace": _has_workspace,
-        "has_bazel_module": _has_module,
         "bazel_version": _bazel_version,
         "deps": _repo_deps,
     }

--- a/test/flag_tests.bzl
+++ b/test/flag_tests.bzl
@@ -4,7 +4,7 @@ load("//:extension.bzl", "parse_opt_out")
 def _parse_opt_out_test(ctx):
   env = unittest.begin(ctx)
 
-  features = ["id", "user", "shell"]
+  features = ["id", "user", "os"]
   groups = {"all": features}
 
   asserts.equals(env, features, parse_opt_out("all", features, groups), "all should mean all")


### PR DESCRIPTION
This change removes collection of the `SHELL` environment variable and `has_bazel_module`. The former is not very interesting, and the latter is always true since the telemetry collection relies on a module extension.

---

### Changes are visible to end-users: no

### Test plan

- Covered by existing test cases
