### PR TITLE
Bring the README up to date with current behavior

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,6 +17,16 @@ Examples:
 - A user adding a new Bazel dependency will invalidate modules and trigger reporting
 - A user making a local code change and performing a build will not trigger reporting
 
+## The notice
+
+The first time the module would report, it prints a notice and sends nothing; reporting
+starts on a later module-graph evaluation, which leaves a window to opt out before
+anything is sent. The record that the notice was shown persists via
+`MODULE.bazel.lock` (Bazel's extension facts). A repository without a lockfile cannot
+carry that record, so it gets a louder notice and reports on the same invocation; on the
+ephemeral CI machines where this typically happens, the notice lands in every job's log,
+so the opt-out is effectively per repository rather than per machine.
+
 ## Controlling reporting
 
 The telemetry module honors `$DO_NOT_TRACK` and will disable itself if this variable is set.
@@ -27,7 +37,11 @@ The telemetry module can be controlled at a finer granularity with the `$ASPECT_
 Some of the collector features can be overridden or salted for further privacy if so desired.
 
 - `$ASPECT_TOOLS_TELEMETRY_SALT` is a value which will be included whenever computing a hash or ID.
-  This allows you to salt correlation IDs if you so choose.
+  This allows you to salt correlation IDs if you so choose. For a public repository, set it as a
+  CI secret rather than committing it, or the salt is as public as the file the ID derives from.
+- `$ASPECT_TOOLS_TELEMETRY_ENDPOINT` overrides where reports are sent. Point it at your own
+  collector and reports go there instead of to Aspect; the payload is the same `report.json`,
+  so anything that accepts a JSON POST works.
 
 ### Example `.bazelrc` configurations
 
@@ -47,10 +61,10 @@ common --repo_env=ASPECT_TOOLS_TELEMETRY=-id_day # just disable the day-scoped r
 
 - `arch`: The arch per `repository_ctx.os.arch`
 - `bazel_version`: The version of Bazel
-- `bazelisk`: Is the `bazelisk` tool is being used
+- `bazelisk`: Whether the `bazelisk` tool is being used
 - `ci`: Is the build occurring in CI/CD or locally
 - `counter`: The build counter if available
-- `deps`: The active set of bzlmod modules which have opted into telemetry
+- `deps`: The modules in `MODULE.bazel.lock` that were resolved from a registry, with versions
 - `has_bazel_prelude`: Does the project use a `prelude_bazel`
 - `has_bazel_tool`: Does the project use a `tools/bazel` script
 - `has_bazel_workspace`: Does the project still have a `WORKSPACE` file
@@ -125,6 +139,21 @@ For transparency reports are persisted into the Bazel configuration and can be i
 ``` shellsession
 ❯ cat $(bazel info output_base)/external/*aspect_tools_telemetry_report/report.json
 ```
+
+## What happens to reports
+
+Reports are received by infrastructure Aspect operates, and are handled as follows:
+
+- `id_day` is re-keyed at ingestion with a server-side secret that rotates daily; each
+  day's outgoing secret is destroyed, so a closed day's stored IDs cannot be matched
+  back to any repository.
+- Fields collected by older versions of this module but not current ones (`user`,
+  `org`, `id`, `shell`, `has_bazel_module`) are discarded at ingestion and never stored.
+- Raw reports are deleted after at most 365 days, and reports that fail processing
+  after 30 days.
+- The aggregate statistics built from reports are published for the community at
+  https://aspect.build/open-source/stats, with the dataset behind the charts at
+  https://stats.aspect.build/stats.json.
 
 ## Privacy policy
 

--- a/examples/notice_once/test.sh
+++ b/examples/notice_once/test.sh
@@ -1,5 +1,8 @@
 #!/usr/bin/env bash
-# Integration test: telemetry notice is shown on first invocation, curl is called on second.
+# Integration test: telemetry notice is shown on first invocation, curl is called on
+# second, and a repository without a lockfile gets the louder uploading notice and a
+# curl call on every invocation (the record that the notice was shown persists via the
+# lockfile, so without one every evaluation is a first evaluation).
 # Requires Bazel 8.5+ (facts API needed to persist notice_version across invocations).
 #
 # ASPECT_TOOLS_TELEMETRY_TEST is observed by the extension via module_ctx.getenv(), so
@@ -72,3 +75,32 @@ if [[ ! -f "$CURL_LOG" ]]; then
 fi
 echo "PASS: curl called on second run"
 echo "curl args: $(cat "$CURL_LOG")"
+
+echo "=== Runs 3 and 4: no lockfile; expect the uploading notice AND a curl call every run ==="
+# Without MODULE.bazel.lock the shown-notice record cannot persist, so every
+# evaluation is a first evaluation. --lockfile_mode=off keeps Bazel from
+# recreating the file between runs, and each run gets a fresh output base to
+# model the realistic lockfile-less case: ephemeral CI, where the repository
+# rule runs every job.
+rm -f "$EXAMPLE_DIR/MODULE.bazel.lock"
+
+for run in 3 4; do
+    RUN_LOG="$WORK_DIR/run$run.log"
+    ASPECT_TOOLS_TELEMETRY_TEST="$run" USE_BAZEL_VERSION=9.x bazel --output_base="$WORK_DIR/output-nolock-$run" build //:report \
+        --lockfile_mode=off \
+        --repo_env "PATH=${REPO_ENV_PATH}" \
+        2>&1 | tee "$RUN_LOG"
+
+    if ! grep -q "Aspect Telemetry is uploading" "$RUN_LOG"; then
+        echo "FAIL: uploading notice was not printed on lockfile-less run $run (expected every run)"
+        exit 1
+    fi
+    echo "PASS: uploading notice printed on lockfile-less run $run"
+
+    if [[ ! -f "$CURL_LOG" ]]; then
+        echo "FAIL: curl was not called on lockfile-less run $run (expected a call every run)"
+        exit 1
+    fi
+    echo "PASS: curl called on lockfile-less run $run"
+    rm -f "$CURL_LOG"
+done

--- a/extension.bzl
+++ b/extension.bzl
@@ -156,16 +156,23 @@ exports_files(["report.json", "defs.bzl"], visibility = ["//visibility:public"])
 """
     )
 
-    # Notify and skip sending if telemetry was not explicitly configured
-    # and the notice has not been seen before.
+    # Notify and skip sending if telemetry was not explicitly configured and
+    # the notice has not been seen before.
+    #
+    # The record that the notice was shown lives in the extension facts, which
+    # persist via MODULE.bazel.lock. Without a lockfile the record has nowhere
+    # to live and every evaluation is a first evaluation (typically ephemeral
+    # CI, where a fresh machine runs each job), so waiting an evaluation would
+    # mean never reporting at all. Those repositories get the louder notice and
+    # report on the same invocation; the opt-out there is effectively per
+    # repository rather than per machine, since the notice lands in the CI log
+    # of every job.
     lockfile_present = repository_ctx.workspace_root.get_child("MODULE.bazel.lock").exists
     if lockfile_present and allowed_telemetry and not repository_ctx.os.environ.get(TELEMETRY_ENV_VAR) and repository_ctx.attr.last_notice != _NOTICE_VERSION:
         # buildifier: disable=print
         print(_NOTICE)
         return
 
-    # If MODULE.bazel.lock is absent we cannot verify whether the notice was
-    # previously shown, so we proceed to send telemetry.
     if not lockfile_present and allowed_telemetry and not repository_ctx.os.environ.get(TELEMETRY_ENV_VAR):
         # buildifier: disable=print
         print(_NOTICE_UPLOADING)


### PR DESCRIPTION
The build-time notice points people at this README for details and opt-out instructions, so it should carry the full picture. This adds what was missing and fixes two inaccuracies:

- **The notice handshake**: prints once and sends nothing, reporting starts on a later evaluation, with the no-lockfile caveat stated.
- **`ASPECT_TOOLS_TELEMETRY_ENDPOINT`**: the destination override was implemented but undocumented here.
- **What happens to reports**: day-scoped re-keying at ingestion with a daily-destroyed secret, legacy fields from older module versions discarded at ingestion, retention (365 days for reports, 30 for reports that fail processing), and links to the published aggregates and the dataset behind them.
- **Salt guidance**: for a public repository, set the salt as a CI secret rather than committing it.
- **Corrections**: `deps` reports every registry-resolved module in the lockfile, not "modules which have opted into telemetry"; and a grammar slip on the `bazelisk` entry.

---

### Changes are visible to end-users: yes

- Searched for relevant documentation and updated as needed: yes
- Breaking change (forces users to change their own code or config): no
- Suggested release notes appear below: no

### Test plan

- Documentation only; statements verified against extension.bzl, collectors/, and the ingest pipeline configuration.
