### PR TITLE
Put the opt-out in the notice itself

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,12 @@
 
 Aspect's ruleset telemetry Bazel module.
 
+> [!TIP]
+> For the full story — what is collected and why, how the data is protected, and
+> every way to opt out — see [our blog post](https://aspect.build/blog/bazel-ecosystem-usage-stats).
+> The public statistics built from this data live at
+> [aspect.build/open-source/stats](https://aspect.build/open-source/stats).
+
 This package defines a Bazel extension which allows for rulesets to report usage to Aspect, allowing us to estimate the install base of Bazel, rulesets, and monitor trends in the ecosystem such as library usage and Bazel versions.
 
 ## When reporting occurs

--- a/extension.bzl
+++ b/extension.bzl
@@ -25,18 +25,24 @@ TELEMETRY_ENV_VAR = "ASPECT_TOOLS_TELEMETRY"
 TELEMETRY_DEST_VAR = "ASPECT_TOOLS_TELEMETRY_ENDPOINT"
 TELEMETRY_DEST = "https://telemetry.aspect.build/ingest?source=tools_telemetry"
 
-_NOTICE_VERSION = 2  # Increment on text changes or data collection changes
+_NOTICE_VERSION = 3  # Increment on text changes or data collection changes
 
 _NOTICE = """\
 Aspect Telemetry will begin collecting ruleset usage data (which Bazel and module versions are in use) on the next invocation, to help us maintain our open source rulesets. Reports carry no user or organization identifiers and are governed by the https://aspect.build/privacy-policy.
 
-See https://github.com/aspect-build/tools_telemetry for the exact fields and opt-out instructions.
+To opt out, add this line to your .bazelrc:
+  common --repo_env=DO_NOT_TRACK=1
+
+See https://github.com/aspect-build/tools_telemetry for the exact fields and finer-grained controls.
 """
 
 _NOTICE_UPLOADING = """\
 Aspect Telemetry is uploading ruleset usage data (which Bazel and module versions are in use) now and on future builds, to help us maintain our open source rulesets. Reports carry no user or organization identifiers and are governed by the https://aspect.build/privacy-policy.
 
-See https://github.com/aspect-build/tools_telemetry for the exact fields and opt-out instructions.
+To opt out, add this line to your .bazelrc:
+  common --repo_env=DO_NOT_TRACK=1
+
+See https://github.com/aspect-build/tools_telemetry for the exact fields and finer-grained controls.
 """
 
 


### PR DESCRIPTION
Community feedback (gholms on Bazel Slack): the notice told people opt-out instructions exist without saying what the opt-out is, so learning it was even possible meant finding and reading this repository.

Both notice variants now carry the one-line `.bazelrc` opt-out directly:

```
To opt out, add this line to your .bazelrc:
  common --repo_env=DO_NOT_TRACK=1
```

The repo link's role shifts to the exact fields and finer-grained controls. The notice version is bumped per the text-change policy, so existing repositories see the updated notice once (and send nothing on that evaluation, as usual).

The README also gains a callout at the top linking [the blog post](https://aspect.build/blog/bazel-ecosystem-usage-stats) and the [public stats page](https://aspect.build/open-source/stats) — the notice sends people here, and that post is the long-form answer to what they came asking.

---

### Changes are visible to end-users: yes

- Searched for relevant documentation and updated as needed: yes
- Breaking change (forces users to change their own code or config): no
- Suggested release notes appear below: yes

Suggested release notes:
- The build-time telemetry notice now includes the one-line `DO_NOT_TRACK` opt-out directly, and is shown once more to existing repositories.

### Test plan

- Covered by existing test cases: the `notice_once` integration test passes all eight assertions — notice-then-no-send on first evaluation, send on the second, and the lockfile-less path unchanged.
